### PR TITLE
終了報告（コミット３）

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,5 +58,5 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
-  config.active_job.queue_adapter = :inline
+  # config.active_job.queue_adapter = :inline
 end

--- a/db/migrate/20240715095457_create_ships.rb
+++ b/db/migrate/20240715095457_create_ships.rb
@@ -1,5 +1,5 @@
 class CreateShips < ActiveRecord::Migration[7.0]
-  def changestreet_address
+  def change
     create_table :ships do |t|
       t.string     :post_code,              null:  false
       t.integer    :region_id,              null:  false     
@@ -12,5 +12,3 @@ class CreateShips < ActiveRecord::Migration[7.0]
     end
   end
 end
-
-

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_09_115643) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_15_095457) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false


### PR DESCRIPTION
shipsテーブルが作成できない（createされない）不具合の対応として、
xxxxxx_create_ships.rb　ファイルの削除・作成を実施。
その後、ローカルで、テーブルが作成されたことを確認した。